### PR TITLE
Updated Item NBT Api to latest version

### DIFF
--- a/farms/build.gradle
+++ b/farms/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     implementation project(":farms-api")
 
     implementation "org.bstats:bstats-bukkit:3.0.0"
-    implementation "de.tr7zw:item-nbt-api:2.10.0"
+    implementation "de.tr7zw:item-nbt-api:2.11.3"
     implementation 'net.kyori:adventure-api:4.12.0'
     implementation 'net.kyori:adventure-platform-bukkit:4.1.2'
     implementation 'dev.triumphteam:triumph-gui:3.1.3'


### PR DESCRIPTION
To make the plugin work on 1.20 we can update the [Item NBT Api](https://github.com/tr7zw/Item-NBT-API) to latest version, I use your plugin and fixed it with this, I had this error
```sh
[04:40:44] [Server thread/INFO]: [Farms] Loading existing farms..
[04:40:44] [Server thread/ERROR]: Error occurred while enabling Farms v1.8 (Is it up to date?)
me.lorenzo0111.farms.libs.nbt.NbtApiException: [?]Error while calling the method 'putString(java.lang.String,java.lang.String)', loaded: true, Enum: COMPOUND_SET_STRING Passed Class: class java.lang.Boolean
    at me.lorenzo0111.farms.libs.nbt.utils.nmsmappings.ReflectionMethod.run(ReflectionMethod.java:185) ~[Farms.jar:?]
    at me.lorenzo0111.farms.libs.nbt.NBTReflectionUtil.setData(NBTReflectionUtil.java:611) ~[Farms.jar:?]
    at me.lorenzo0111.farms.libs.nbt.NBTCompound.setString(NBTCompound.java:102) ~[Farms.jar:?]
    at me.lorenzo0111.farms.commands.subcommands.CreateCommand.getItem(CreateCommand.java:78) ~[Farms.jar:?]
    at me.lorenzo0111.farms.commands.subcommands.CreateCommand.resetItem(CreateCommand.java:86) ~[Farms.jar:?]
    at me.lorenzo0111.farms.Farms.reload(Farms.java:212) ~[Farms.jar:?]
    at me.lorenzo0111.farms.Farms.onEnable(Farms.java:115) ~[Farms.jar:?]
    at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:281) ~[purpur-api-1.20.1-R0.1-SNAPSHOT.jar:?]
    at 
```